### PR TITLE
correctly display text under cursor in underdash/vertical line cursor mode

### DIFF
--- a/emulatorview/src/main/java/jackpal/androidterm/emulatorview/BaseTextRenderer.java
+++ b/emulatorview/src/main/java/jackpal/androidterm/emulatorview/BaseTextRenderer.java
@@ -317,7 +317,7 @@ abstract class BaseTextRenderer implements TextRenderer {
     private Bitmap mCursorBitmap;
     private Bitmap mWorkBitmap;
     private int mCursorBitmapCursorMode = -1;
-    protected int mCursorStyle = 0;
+    private int mCursorStyle = 0;
 
     public BaseTextRenderer(ColorScheme scheme) {
         if (scheme == null) {
@@ -459,9 +459,12 @@ abstract class BaseTextRenderer implements TextRenderer {
         }
     }
 
-    public void setCursorStyle(int cursorStyle)
-    {
+    public void setCursorStyle(int cursorStyle) {
         mCursorStyle = cursorStyle;
+    }
+
+    public int getCursorStyle(){
+        return mCursorStyle;
     }
 }
 

--- a/emulatorview/src/main/java/jackpal/androidterm/emulatorview/BaseTextRenderer.java
+++ b/emulatorview/src/main/java/jackpal/androidterm/emulatorview/BaseTextRenderer.java
@@ -317,7 +317,7 @@ abstract class BaseTextRenderer implements TextRenderer {
     private Bitmap mCursorBitmap;
     private Bitmap mWorkBitmap;
     private int mCursorBitmapCursorMode = -1;
-    private int mCursorStyle = 0;
+    protected int mCursorStyle = 0;
 
     public BaseTextRenderer(ColorScheme scheme) {
         if (scheme == null) {

--- a/emulatorview/src/main/java/jackpal/androidterm/emulatorview/PaintRenderer.java
+++ b/emulatorview/src/main/java/jackpal/androidterm/emulatorview/PaintRenderer.java
@@ -107,7 +107,11 @@ class PaintRenderer extends BaseTextRenderer {
                     canvas.drawText(text, index, countBeforeCursor, left, textOriginY, mTextPaint);
                 }
                 // Text at cursor
-                mTextPaint.setColor(mPalette[TextStyle.ciCursorForeground]);
+                // Only use invert color with BLOCK cursor.
+                // For underdash and vertical line, use normal color.
+                if(mCursorStyle == 0) {
+                    mTextPaint.setColor(mPalette[TextStyle.ciCursorForeground]);
+                }
                 canvas.drawText(text, cursorIndex, cursorIncr, cursorX,
                         textOriginY, mTextPaint);
                 // Text after cursor

--- a/emulatorview/src/main/java/jackpal/androidterm/emulatorview/PaintRenderer.java
+++ b/emulatorview/src/main/java/jackpal/androidterm/emulatorview/PaintRenderer.java
@@ -109,7 +109,7 @@ class PaintRenderer extends BaseTextRenderer {
                 // Text at cursor
                 // Only use invert color with BLOCK cursor.
                 // For underdash and vertical line, use normal color.
-                if(mCursorStyle == 0) {
+                if(getCursorStyle() == 0) {
                     mTextPaint.setColor(mPalette[TextStyle.ciCursorForeground]);
                 }
                 canvas.drawText(text, cursorIndex, cursorIncr, cursorX,


### PR DESCRIPTION
Sorry to issue a pull request again. There's a problem in text rendering. Char under cursor was rendered with inverted color but in vertical line/underline mode it should be rendered with just normal color.
